### PR TITLE
Fixup! zero width space

### DIFF
--- a/lib/mail/multibyte/unicode.rb
+++ b/lib/mail/multibyte/unicode.rb
@@ -59,7 +59,7 @@ module Mail
         0x00A0,                # White_Space # Zs       NO-BREAK SPACE
         0x1680,                # White_Space # Zs       OGHAM SPACE MARK
         0x180E,                # White_Space # Zs       MONGOLIAN VOWEL SEPARATOR
-        (0x2000..0x200A).to_a, # White_Space # Zs  [11] EN QUAD..HAIR SPACE
+        (0x2000..0x200B).to_a, # White_Space # Zs  [11] EN QUAD..HAIR SPACE
         0x2028,                # White_Space # Zl       LINE SEPARATOR
         0x2029,                # White_Space # Zp       PARAGRAPH SEPARATOR
         0x202F,                # White_Space # Zs       NARROW NO-BREAK SPACE

--- a/spec/mail/elements/address_list_spec.rb
+++ b/spec/mail/elements/address_list_spec.rb
@@ -82,6 +82,20 @@ describe Mail::AddressList do
       a = Mail::AddressList.new(parse_text)
       expect(a.addresses.first.comments).to eq result
     end
+
+    it "should handle zero width space" do
+      parse_text = "foo@example.com, \u200b bar@example.com"
+      result = ['foo@example.com', 'bar@example.com']
+      a = Mail::AddressList.new(parse_text)
+      expect(a.addresses.map {|addr| addr.to_s }).to eq result
+    end
+
+    it "should handle zero width space near valid address" do
+      parse_text = "foo@example.com, \u200bbar@example.com"
+      result = ['foo@example.com', 'bar@example.com']
+      a = Mail::AddressList.new(parse_text)
+      expect(a.addresses.map {|addr| addr.to_s }).to eq result
+    end
   end
 
   describe "functionality" do


### PR DESCRIPTION
Trying to fixup things, but they only use the custom #strip on ruby versions < 1.9. We need to change the `case` inside the file "address_lists_parser.rb" (big mess there).